### PR TITLE
Update mariadb.yml

### DIFF
--- a/apps/addons/mariadb.yml
+++ b/apps/addons/mariadb.yml
@@ -9,8 +9,8 @@ services:
       - 'PUID=${ID}'
       - 'TZ=${TZ}'
       - 'UMASK=${UMASK}'
-      - 'MYSQL_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}'
-    image: 'mariadb:latest'
+      - 'MYSQL_ROOT_PASSWORD=password'
+    image: 'linuxserver/mariadb:amd64-alpine-version-10.5.11-r0'
     restart: '${RESTARTAPP}'
     ports:
       - '${PORTBLOCK}:3306:3306'
@@ -19,9 +19,9 @@ services:
     security_opt:
       - 'no-new-privileges:true'
     volumes:
-      - '${APPFOLDER}/mariadb:/var/lib/mysql:rw'
+      - '${APPFOLDER}/mariadb:/config:rw'
     labels:
-      - 'dockupdater.enable=true'
+      - 'dockupdater.enable=false'
 networks:
   proxy:
     driver: bridge


### PR DESCRIPTION
switch to linuxserver image (pgid&puid jail)
changed valume according to linuxsever docker image
fixed version to 10.5.11-r0 (newer versions cause issues with nextcloud)
disabled auto update