### PR TITLE
FAILSAFE: backups don't get overwritten.

### DIFF
--- a/scripts/backup/backupdate.sh
+++ b/scripts/backup/backupdate.sh
@@ -30,7 +30,7 @@
 
 ## USER SETTINGS
 HOSTNAME=$(cat /etc/hostname)
-tag=local
+tag=local # tag can also be a date, Example | tag=$(date "+%Y-%m-%d")
 STORAGE=$HOSTNAME-$tag # Remove HOSTNAME if you only want to use the tag, Example | STORAGE=$tag
 ### ENF OF SETTINGS
 

--- a/scripts/backup/backupdate.sh
+++ b/scripts/backup/backupdate.sh
@@ -30,6 +30,7 @@
 
 ## USER SETTINGS
 STORAGE=local
+TAG=$(cat /etc/hostname)
 ### ENF OF SETTINGS
 
 OPTIONSTAR="--warning=no-file-changed \
@@ -46,7 +47,7 @@ dockers=$(docker ps -aq --format '{{.Names}}' | sed '/^$/d' | grep -v 'trae' | g
 for i in ${dockers};do
    ARCHIVE=$i
    ARCHIVETAR=${ARCHIVE}.tar.gz
-   if [[ ! -d ${DESTINATION}/${STORAGE} ]];then $(command -v mkdir) -p ${DESTINATION}/${STORAGE};fi
+   if [[ ! -d ${DESTINATION}/${TAG}-${STORAGE} ]];then $(command -v mkdir) -p ${DESTINATION}/${TAG}-${STORAGE};fi
    forcepush="tar pigz pv"
    for fc in ${forcepush};do
        $(command -v apt) install $fc --reinstall -yqq 1>/dev/null 2>&1 && sleep 1
@@ -59,12 +60,12 @@ for i in ${dockers};do
    done
    if [[ ${section} == "mediaserver" || ${section} == "mediamanager" ]];then
       $(command -v docker) stop ${typed} 1>/dev/null 2>&1 && echo "We stopped now $typed"
-      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${STORAGE}/${ARCHIVETAR} ./
+      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${TAG}-${STORAGE}/${ARCHIVETAR} ./
       $(command -v docker) start ${typed} 1>/dev/null 2>&1  && echo "We started now $typed"
    else
-      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${STORAGE}/${ARCHIVETAR} ./
+      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${TAG}-${STORAGE}/${ARCHIVETAR} ./
    fi
-   $(command -v chown) -hR 1000:1000 ${DESTINATION}/${STORAGE}/${ARCHIVETAR}
+   $(command -v chown) -hR 1000:1000 ${DESTINATION}/${TAG}-${STORAGE}/${ARCHIVETAR}
 done
 
 #EOF

--- a/scripts/backup/backupdate.sh
+++ b/scripts/backup/backupdate.sh
@@ -29,8 +29,9 @@
 ## STORAGE=$(date "+%Y-%m-%d")
 
 ## USER SETTINGS
-STORAGE=local
-TAG=$(cat /etc/hostname)
+HOSTNAME=$(cat /etc/hostname)
+tag=local
+STORAGE=$HOSTNAME-$tag # Remove HOSTNAME if you only want to use the tag, Example | STORAGE=$tag
 ### ENF OF SETTINGS
 
 OPTIONSTAR="--warning=no-file-changed \
@@ -47,7 +48,7 @@ dockers=$(docker ps -aq --format '{{.Names}}' | sed '/^$/d' | grep -v 'trae' | g
 for i in ${dockers};do
    ARCHIVE=$i
    ARCHIVETAR=${ARCHIVE}.tar.gz
-   if [[ ! -d ${DESTINATION}/${TAG}-${STORAGE} ]];then $(command -v mkdir) -p ${DESTINATION}/${TAG}-${STORAGE};fi
+   if [[ ! -d ${DESTINATION}/${STORAGE} ]];then $(command -v mkdir) -p ${DESTINATION}/${STORAGE};fi
    forcepush="tar pigz pv"
    for fc in ${forcepush};do
        $(command -v apt) install $fc --reinstall -yqq 1>/dev/null 2>&1 && sleep 1
@@ -60,12 +61,12 @@ for i in ${dockers};do
    done
    if [[ ${section} == "mediaserver" || ${section} == "mediamanager" ]];then
       $(command -v docker) stop ${typed} 1>/dev/null 2>&1 && echo "We stopped now $typed"
-      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${TAG}-${STORAGE}/${ARCHIVETAR} ./
+      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${STORAGE}/${ARCHIVETAR} ./
       $(command -v docker) start ${typed} 1>/dev/null 2>&1  && echo "We started now $typed"
    else
-      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${TAG}-${STORAGE}/${ARCHIVETAR} ./
+      $(command -v tar) ${OPTIONSTAR} -C ${FOLDER}/${ARCHIVE} -pcf ${DESTINATION}/${STORAGE}/${ARCHIVETAR} ./
    fi
-   $(command -v chown) -hR 1000:1000 ${DESTINATION}/${TAG}-${STORAGE}/${ARCHIVETAR}
+   $(command -v chown) -hR 1000:1000 ${DESTINATION}/${STORAGE}/${ARCHIVETAR}
 done
 
 #EOF


### PR DESCRIPTION
Added fail-safe to ensure backups from different servers don't get overwritten. Even if it fails to grab the `hostname` the backup should work.

Example: 
Instance One: `mediabox-local` (If hostname is mediabox); instead of just being `local`.
Instance Two: `feeder-local` (If hostname is feeder); instead of just being `local`. 