### PR TITLE
Update plex.yml

### DIFF
--- a/apps/.subactions/plex.yml
+++ b/apps/.subactions/plex.yml
@@ -164,6 +164,13 @@
         attribute: allowLocalhostOnly
         value: '0'
       when: plex_prefs.stat.exists
+    - name: 'Add Generate BIFF Interval'
+      xml:
+        path: '/opt/appdata/plex/database/Library/Application Support/Plex Media Server/Preferences.xml'
+        xpath: /Preferences
+        attribute: GenerateBIFFrameInterval
+        value: '10'
+      when: plex_prefs.stat.exists
 
     - name: 'Check /dev/dri exists'
       stat:


### PR DESCRIPTION
Makes video thumbnails smaller to keep /opt/appdata/plex from becoming overly bloated (Saves GB in size, currently using in my production server). Serves as a background function. Only works if the user enables "create video thumbnails on the library."  "Otherwise remains dormant.