### PR TITLE
Update for Bypassing Uptime-Kuma Status Page

### DIFF
--- a/traefik/templates/authelia/configuration.yml
+++ b/traefik/templates/authelia/configuration.yml
@@ -70,6 +70,14 @@ access_control:
         - "^/control.*$"
         - "^/meshrelay.*$"
         - "^/wl/.*$"
+    ## bypass rule for Uptime-Kuma (Status Page)
+    - domain: "uptime-kuma.example.com"
+      policy: bypass
+      resources:
+        - "^/status-page?.*$"
+        - "^/assets/.*$"
+        - "^/upload/logo.png.*$"
+        - "^/icon.svg"    
     ## block admin bitwarden.example.com resources
     - domain: "bitwarden.example.com"
       policy: one_factor


### PR DESCRIPTION
With this Bypass rule we can use authelia for Uptime-Kuma, but also share the Status Page to users without the need to Authenticate!