### PR TITLE
docs(wiki): update tauticord

### DIFF
--- a/wiki/docs/apps/addons/tauticord.md
+++ b/wiki/docs/apps/addons/tauticord.md
@@ -84,7 +84,7 @@ logLevel: WARN
 
 Tautulli:
   Connection:
-    URL: "http://tatulli:8181" # change this if tautulli is not installed from Dockserver.
+    URL: "http://tautulli:8181" # change this if tautulli is not installed from Dockserver.
     APIKey: ""
   Customization:
     TerminateMessage: "Your stream has been terminated. Please contact the admin in the Discord."


### PR DESCRIPTION
misspelled name in Tautulli Url.