### PR TITLE
Update bazarr.yml network name

### DIFF
--- a/apps/mediamanager/bazarr.yml
+++ b/apps/mediamanager/bazarr.yml
@@ -32,7 +32,7 @@ services:
       - "traefik.http.routers.bazarr-rtr.service=bazarr-svc"
       - "traefik.http.services.bazarr-svc.loadbalancer.server.port=6767"
 networks:
-  ${DOCKERNETWORK}:
+  proxy:
     driver: bridge
     external: true
 volumes:


### PR DESCRIPTION
network name substitution doesn't work in docker compose.  see https://github.com/moby/moby/issues/40819#issuecomment-618726892