### PR TITLE
Update invitarr.yml network name

### DIFF
--- a/apps/mediamanager/invitarr.yml
+++ b/apps/mediamanager/invitarr.yml
@@ -31,6 +31,6 @@ services:
       - "traefik.http.routers.invitarr-rtr.service=invitarr-svc"
       - "traefik.http.services.invitarr-svc.loadbalancer.server.port=5001"
 networks:
-  ${DOCKERNETWORK}:
+  proxy:
     driver: bridge
     external: true


### PR DESCRIPTION
network name substitution doesn't work in docker compose.  see https://github.com/moby/moby/issues/40819#issuecomment-618726892