### PR TITLE
Update bazarr4k.yml network name

### DIFF
--- a/apps/mediamanager/bazarr4k.yml
+++ b/apps/mediamanager/bazarr4k.yml
@@ -33,7 +33,7 @@ services:
       - "traefik.http.routers.bazarr4k-rtr.service=bazarr-svc"
       - "traefik.http.services.bazarr4k-svc.loadbalancer.server.port=6767"
 networks:
-  ${DOCKERNETWORK}:
+  proxy:
     driver: bridge
     external: true
 volumes:


### PR DESCRIPTION
network name substitution doesn't work in docker compose.  see https://github.com/moby/moby/issues/40819#issuecomment-618726892